### PR TITLE
cosmetic changes

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -238,14 +238,14 @@ def fatal(*tokens, **kwargs):
 
 def error(*tokens, **kwargs):
     """ Print an error message """
-    tokens = [bold, red, "[ERROR]:"] + list(tokens)
+    tokens = [bold, red, "Error:"] + list(tokens)
     kwargs["fileobj"] = sys.stderr
     message(*tokens, **kwargs)
 
 
 def warning(*tokens, **kwargs):
     """ Print a warning message """
-    tokens = [brown, "[WARN ]:"] + list(tokens)
+    tokens = [brown, "Warning:"] + list(tokens)
     kwargs["fileobj"] = sys.stderr
     message(*tokens, **kwargs)
 
@@ -329,7 +329,6 @@ def debug(*tokens, **kwargs):
     """
     if not CONFIG["verbose"] or CONFIG["record"]:
         return
-    tokens = [blue, "[DEBUG]:"] + list(tokens)
     message(*tokens, **kwargs)
 
 


### PR DESCRIPTION
Replace ugly [ERROR] and [WARN ] prefixes by something nicer to read,
and remove [DEBUG] prefix.

This fixes using `tsrc` with the `--verbose` flag:

Old:
     => Updating manifest
     [DEBUG]: /home/dmerej/tmp/tsrc/.tsrc/manifest $ git fetch --prune origin
     [DEBUG]: /home/dmerej/tmp/tsrc/.tsrc/manifest $ git reset --hard @{u}
     HEAD is now at e2f8457 add gitlab url

New:
     => Updating manifest
     /home/dmerej/tmp/tsrc/.tsrc/manifest $ git fetch --prune origin
     /home/dmerej/tmp/tsrc/.tsrc/manifest $ git reset --hard @{u}

Trivia:

This used to make sense back when ui.py was used as a logger
(a long time ago):

     [DEBUG] this is a debug message
     [INFO ] this is a info message
     [WARN ] this is a warning message
     [ERROR] this is an error message

Turned out we almost always something displayed to the screen between
ui.message() calls, so alignment does not matter much,
and the [INFO ] prefix was just noise.

So we removed the [INFO ] prefix from ui.info() but unintentionally left it in
ui.debug(), ui.warning(), and ui.error()

This change was already made in `tsrc` back in https://github.com/TankerApp/tsrc/commit/35b4b6db5a05d2e1f3e09dc687dc4787905bf20c
but somehow was lost when `ui.py` was extracted to its own project.

Sorry!