### PR TITLE
Optional sort on ask_choice

### DIFF
--- a/cli_ui/__init__.py
+++ b/cli_ui/__init__.py
@@ -494,8 +494,8 @@ FuncDesc = Callable[[Any], str]
 
 
 def ask_choice(
-    *prompt: Token, choices: List[Any], func_desc: Optional[FuncDesc] = None
-) -> Any:
+    *prompt: Token, choices: List[Any], func_desc: Optional[FuncDesc] = None,
+    sort: Optional[bool] = True) -> Any:
     """Ask the user to choose from a list of choices.
 
     :return: the selected choice
@@ -514,7 +514,8 @@ def ask_choice(
         func_desc = lambda x: str(x)
     tokens = get_ask_tokens(prompt)
     info(*tokens)
-    choices.sort(key=func_desc)
+    if sort:
+        choices.sort(key=func_desc)
     for i, choice in enumerate(choices, start=1):
         choice_desc = func_desc(choice)
         info("  ", blue, "%i" % i, reset, choice_desc)


### PR DESCRIPTION
Hi,

I added a "sort" optional argument to ask_choice to be able to choose if you want to sort the list or not.
This is useful in case the list is already in an order you don't want to modify and that is messed up by any sorting (e.g. to simply keep it in order of insertion). The default value is set to True for backward compatibility.