### PR TITLE
Simplify detection and support of ansi codes

### DIFF
--- a/cli_ui/__init__.py
+++ b/cli_ui/__init__.py
@@ -148,7 +148,7 @@ class Symbol(UnicodeSequence):
         return (self.as_string,)
 
 
-def config_color(fileobj: FileObj) -> bool:
+def colors_enabled(fileobj: FileObj) -> bool:
     # if CONFIG["color"] has been set, i.e, different
     # from "auto", use it:
     if CONFIG["color"] == "never":
@@ -253,7 +253,7 @@ def message(
         _MESSAGES.append(without_color)
     if update_title and with_color:
         write_title_string(without_color, fileobj)
-    to_write = with_color if config_color(fileobj) else without_color
+    to_write = with_color if colors_enabled(fileobj) else without_color
     write_and_flush(fileobj, to_write)
 
 
@@ -401,7 +401,7 @@ def info_table(
             plain_row.append(plain_str)
         colored_data.append(colored_row)
         plain_data.append(plain_row)
-    if config_color(fileobj):
+    if colors_enabled(fileobj):
         data_for_tabulate = colored_data
     else:
         data_for_tabulate = plain_data

--- a/cli_ui/__init__.py
+++ b/cli_ui/__init__.py
@@ -353,7 +353,7 @@ def info_progress(prefix: str, value: float, max_value: float) -> None:
 
 
     """
-    if sys.stdout.isatty():
+    if colors_enabled(sys.stdout):
         percent = float(value) / max_value * 100
         to_write = prefix + ": %.0f%%\r" % percent
         write_and_flush(sys.stdout, to_write)

--- a/cli_ui/__init__.py
+++ b/cli_ui/__init__.py
@@ -626,38 +626,29 @@ def main_test_colors() -> None:
 
 
 def main_demo() -> None:
-    info("OK", check)
-    up = Symbol("👍", "+1")
-    info("I like it", blue, up)
     info_section(bold, "python-cli demo")
-    # Monkey-patch message() so that we sleep after
-    # each call
-    global message
-    old_message = message
 
-    def new_message(*args: Any, **kwargs: Any) -> None:
-        old_message(*args, **kwargs)
-        time.sleep(1)
-
-    message = new_message
+    info("OK", check)
 
     info_1("Important info")
     info_2("Secondary info")
     info("This is", red, "red")
     info("this is", bold, "bold")
+    up = Symbol("👍", "+1")
+    info("I like it", blue, up)
+
     list_of_things = ["foo", "bar", "baz"]
     for i, thing in enumerate(list_of_things):
         info_count(i, len(list_of_things), thing)
-    info_progress("Done", 5, 20)
-    info_progress("Done", 10, 20)
-    info_progress("Done", 20, 20)
-    info("\n", check, "all done")
 
-    # stop monkey patching
-    message = old_message
-    fruits = ["apple", "orange", "banana"]
-    answer = ask_choice("Choose a fruit", choices=fruits)
-    info("You chose:", answer)
+    time.sleep(0.5)
+    info_progress("Doing something", 5, 20)
+    time.sleep(0.5)
+    info_progress("Doing something", 10, 20)
+    time.sleep(0.5)
+    info_progress("Doing something", 20, 20)
+    time.sleep(0.5)
+    info("\n", check, "all done")
 
 
 def main() -> None:

--- a/cli_ui/__init__.py
+++ b/cli_ui/__init__.py
@@ -355,8 +355,8 @@ def info_progress(prefix: str, value: float, max_value: float) -> None:
     """
     if sys.stdout.isatty():
         percent = float(value) / max_value * 100
-        sys.stdout.write(prefix + ": %.0f%%\r" % percent)
-        sys.stdout.flush()
+        to_write = prefix + ": %.0f%%\r" % percent
+        write_and_flush(sys.stdout, to_write)
 
 
 def debug(*tokens: Token, **kwargs: Any) -> None:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,19 @@
 Changelog
 ----------
 
+v0.11.0
++++++++
+
+* Implement `CLICOLORS standard <https://bixense.com/clicolors/>`_.
+
+* **breaking**:  Remove buggy workarounds when used on Windows.
+  Colors will now be off by default when using `mintty`, but
+  can be activated by setting `CLICOLORS_FORCE=1` as an environment
+  variable. See `#51 <https://github.com/TankerHQ/python-cli-ui/issues/51>`_ 
+  for details.
+
+
+
 v0.10.3
 +++++++
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,11 +16,7 @@ Tools for nice user interfaces in the terminal.
 Installation
 -------------
 
-``cli-ui`` is available on `Pypi <https://pypi.org/project/cli-ui/>`_
-and is compatible with Python **3.4** and higher.
-
-It depends on ``colorama`` and ``unidecode`` for Windows support, and on
-``tabulate`` for the :func:`info_table` function.
+``cli-ui`` is available on `Pypi <https://pypi.org/project/cli-ui/>`_.
 
 API
 ----


### PR DESCRIPTION
* Always call colorama.init()
* Implement CLICOLORS standard
* Remove the `mintty` workaround
* Remove workaround when setting terminal title

Note: this means that getting garbage output is less likely, but
it also means you now *have* to set CLICOLRS_FORCE=1 when
using programs that depends on cli-ui on mintty

Fix #51 