### PR TITLE
Allow calling fatal() with a custom exit code

### DIFF
--- a/cli_ui/__init__.py
+++ b/cli_ui/__init__.py
@@ -252,10 +252,11 @@ def message(
     write_and_flush(fileobj, to_write)
 
 
-def fatal(*tokens: Token, **kwargs: Any) -> None:
-    """Print an error message and call ``sys.exit``"""
+def fatal(*tokens: Token, exit_code: int = 1, **kwargs: Any) -> None:
+    """Print an error message and call ``sys.exit` with a given
+    `exit_code` (default: 1)`"""
     error(*tokens, **kwargs)
-    sys.exit(1)
+    sys.exit(exit_code)
 
 
 def error(*tokens: Token, **kwargs: Any) -> None:

--- a/cli_ui/tests/test_cli_ui.py
+++ b/cli_ui/tests/test_cli_ui.py
@@ -331,6 +331,20 @@ def test_quiet(message_recorder: MessageRecorder) -> None:
     assert not message_recorder.find("info")
 
 
+def test_fatal() -> None:
+    cli_ui.setup(quiet=True)
+    with pytest.raises(SystemExit) as e:
+        cli_ui.fatal("default exit code")
+    assert e.value.code == 1
+
+
+def test_fatal_with_custom_code() -> None:
+    cli_ui.setup(quiet=True)
+    with pytest.raises(SystemExit) as e:
+        cli_ui.fatal("custom exit code", exit_code=3)
+    assert e.value.code == 3
+
+
 def test_color_always(dumb_tty: DumbTTY) -> None:
     cli_ui.setup(color="always")
     cli_ui.info(cli_ui.red, "this is red", fileobj=dumb_tty)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ----------
 
+unreleased
+++++++++++
+
+* `fatal` can now be called with a custom exit code, different than
+  the default 1.
+
 v0.14.1 (2021-06-06)
 ++++++++++++++++++++
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -194,7 +194,13 @@ Functions below use ``sys.stderr`` by default:
 
       >>> cli_ui.fatal("Message")
       Error: message
-      exit()
+      exit(1)
+
+    ::
+
+      >>> cli_ui.fatal("Another message", exit_code=2)
+      Error: message
+      exit(2)
 
 
 Progress messages


### PR DESCRIPTION
different than the default 1.

That will be useful for me (and hopefully other users) that are using various exit codes to distinguish different kind of errors (f.e. https://github.com/egnyte/gitlabform/blob/485a8f3ae34885732cc0141f2108820681049b21/gitlabform/__init__.py). 

(For now I have to use `logging.fatal` + `sys.exit(custom_code)` whenever I want to exit with non-1. :/ )