### PR TITLE
Restore badge with Python 3.6, switch to 3.9 as main

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,10 +14,10 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Install and configure poetry
       run: |

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -15,10 +15,10 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Install and configure poetry
       run: |

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
+        python-version: [3.9]
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ Issues = "https://github.com/dmerejkowsky/python-cli-ui/issues"
 
 [tool.poetry.dependencies]
 # Keep this in sync with .github/workflows/
-python = "^3.6.2"
+python = "^3.6"
 colorama = "^0.4.1"
 tabulate = "^0.8.3"
 unidecode = "^1.0.23"


### PR DESCRIPTION
The badge in README depends on the classifiers in PyPI and these depend on the value of `python` in `pyproject.toml`. 

And apparently you can't have `^3.6.2` - you need `^3.6` to get a classifier with 3.6 support, if I am reading the historing releases in PyPI metadata right.

I think that the lesser evil is to have slightly theoretically incorrect dependencies declared (and for the dev-only tool black), but a more correct project metadata for such an important thing as Python version compatibility.